### PR TITLE
Standard CommonJS module.exports if

### DIFF
--- a/insQ.js
+++ b/insQ.js
@@ -158,6 +158,6 @@ var insertionQ = (function () {
     return exports;
 })();
 
-if(module) {
-    module.exports = insertionQ;
+if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
+  module.exports = insertionQ;
 }


### PR DESCRIPTION
Simply testing for `module` results in `Uncaught ReferenceError: module is not defined`.