### PR TITLE
I3996 joyride double click

### DIFF
--- a/insQ.js
+++ b/insQ.js
@@ -10,7 +10,7 @@ var insertionQ = (function () {
         elm = document.createElement('div'),
         options = {
             strictlyNew: true,
-            timeout: 20
+            timeout: 0
         };
     
     // determine if timeout is required in order register event listener immediately


### PR DESCRIPTION
This should fix the double click issue in the joyride. The timeout is still defaulting to 20 ms. By now defaulting to 0 ms, the event listener will immediately be registered after the animation plays. So single/double clicking will not cause the joyride to break. 